### PR TITLE
fix: sync package-lock with workspace deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@ton/core": "^0.63.1",
-        "@ton/ton": "16.2.2",
+        "@ton/ton": "16.2.4",
         "@tonconnect/ui-react": "^2.4.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -128,6 +128,30 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "app/node_modules/@ton/ton": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@ton/ton/-/ton-16.2.4.tgz",
+      "integrity": "sha512-GWCNKizQm7MM99XNQGr+zWWdSfbFu/WLeQYm7tMIQDNKpAYEpLDKJUKuK/yrz763DBbnTDAFeq1NWAEy8rAOaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.15.0",
+        "dataloader": "^2.0.0",
+        "zod": "^3.21.4"
+      },
+      "peerDependencies": {
+        "@ton/core": ">=0.63.0 <1.0.0",
+        "@ton/crypto": ">=3.2.0"
+      }
+    },
+    "app/node_modules/@ton/ton/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "app/node_modules/@types/node": {


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Related issues

<!-- e.g. Closes #42 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor / quality (no behaviour change)
- [ ] Tests
- [ ] CI / tooling / dependencies
- [ ] Breaking change (describe migration below)

## Checklist

Run these from the repo root. This repo uses npm workspaces and a single root `package-lock.json`.

- [ ] `npm ci --legacy-peer-deps` succeeds
- [ ] `npm run app:verify` succeeds
- [ ] `PW_WORKERS=1 npm run app:test:e2e` succeeds (when UI/routes changed)
- [ ] `npm run contracts:test` succeeds (when contracts changed)
- [ ] `npm run contracts:typecheck` succeeds (when contracts changed)
- [ ] Tested manually in a browser when UI behaviour changed
- [ ] No unjustified `any`, no stray `console.log` / debug code in production paths
- [ ] New UI uses existing Tailwind / component patterns; GSAP plugins registered only where the project already does (e.g. `App.tsx`)
- [ ] Docs updated if user-facing behaviour or setup changed

## Screenshots / recordings

<!-- For visual changes, add before/after or a short clip. -->

## Breaking changes

<!-- If applicable: what breaks and how consumers should migrate. -->
