### PR TITLE
feat(demo): hard cut snap to next section when pinned hero ends

### DIFF
--- a/app/src/sections/HeroSection.tsx
+++ b/app/src/sections/HeroSection.tsx
@@ -22,6 +22,10 @@ const HeroTokenHologram = lazy(() => import('@/experience/HeroTokenHologram'));
 
 gsap.registerPlugin(ScrollTrigger);
 
+function clamp01(v: number) {
+  return Math.min(1, Math.max(0, v));
+}
+
 const TICKER_DATA = [
   { label: 'AI AGENTS', value: '' },
   { label: 'SUPPLY', value: '' },
@@ -179,11 +183,19 @@ const HeroSection: React.FC<HeroSectionProps> = ({ cinematic = false }) => {
       gsap.set(cut, { willChange: 'transform, opacity', opacity: 0, yPercent: 110 });
 
       const setScrub = (p: number) => {
-        const v = Math.max(0, Math.min(1, p));
+        const v = clamp01(p);
         document.documentElement.style.setProperty('--demo-scrub', v.toFixed(3));
         window.dispatchEvent(new CustomEvent('solaris:demoScrub', { detail: { progress: v } }));
       };
       setScrub(0);
+
+      const hardCut = () => {
+        const target = document.querySelector<HTMLElement>('#problem-agriculture');
+        if (!target) return;
+        window.dispatchEvent(new CustomEvent('solaris:demoBeat', { detail: { intensity: 1 } }));
+        const y = target.getBoundingClientRect().top + window.scrollY;
+        window.scrollTo({ top: y, behavior: 'smooth' });
+      };
 
       const tl = gsap.timeline({
         defaults: { ease: 'none' },
@@ -196,6 +208,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ cinematic = false }) => {
           anticipatePin: 1,
           pinSpacing: true,
           onUpdate: (self) => setScrub(self.progress),
+          onLeave: () => hardCut(),
         },
       });
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Related issues

<!-- e.g. Closes #42 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor / quality (no behaviour change)
- [ ] Tests
- [ ] CI / tooling / dependencies
- [ ] Breaking change (describe migration below)

## Checklist

Run these from the repo root. This repo uses npm workspaces and a single root `package-lock.json`.

- [ ] `npm ci --legacy-peer-deps` succeeds
- [ ] `npm run app:verify` succeeds
- [ ] `PW_WORKERS=1 npm run app:test:e2e` succeeds (when UI/routes changed)
- [ ] `npm run contracts:test` succeeds (when contracts changed)
- [ ] `npm run contracts:typecheck` succeeds (when contracts changed)
- [ ] Tested manually in a browser when UI behaviour changed
- [ ] No unjustified `any`, no stray `console.log` / debug code in production paths
- [ ] New UI uses existing Tailwind / component patterns; GSAP plugins registered only where the project already does (e.g. `App.tsx`)
- [ ] Docs updated if user-facing behaviour or setup changed

## Screenshots / recordings

<!-- For visual changes, add before/after or a short clip. -->

## Breaking changes

<!-- If applicable: what breaks and how consumers should migrate. -->
