### PR TITLE
fix(price): support current DeDust schema and show unavailable state

### DIFF
--- a/app/src/hooks/use-live-pool-data.ts
+++ b/app/src/hooks/use-live-pool-data.ts
@@ -5,8 +5,9 @@ import { CET_CONTRACT_ADDRESS } from '@/lib/cetContract';
 const REFRESH_INTERVAL_MS = 60_000;
 
 interface DeDustPrice {
-  address: string;
-  price: string;
+  address?: string;
+  symbol?: string;
+  price: string | number;
 }
 
 export interface PoolData {
@@ -64,7 +65,7 @@ export function useLivePoolData(): PoolData {
       }
       const signal = createTimeoutSignal(8000);
       const isDev = import.meta.env.DEV;
-      const pricesUrl = isDev ? '/api-dedust/v2/prices' : 'https://api.dedust.io/v2/prices';
+      const pricesUrl = isDev ? '/api-dedust/v2/prices' : 'https://mainnet.api.dedust.io/v2/prices';
 
       // Fetch chain state (cached promise) and live prices (small 1.1 KB)
       const [state, pricesRes] = await Promise.all([
@@ -77,10 +78,20 @@ export function useLivePoolData(): PoolData {
       }
 
       const prices: DeDustPrice[] = await pricesRes.json();
+      const parseUsd = (v: string | number | null | undefined): number | null => {
+        if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+        if (typeof v === 'string') {
+          const n = Number.parseFloat(v);
+          return Number.isFinite(n) ? n : null;
+        }
+        return null;
+      };
 
       // Get TON USD price from prices endpoint
-      const tonEntry = prices.find((p) => p.address === 'native');
-      const tonPriceUsd = tonEntry ? parseFloat(tonEntry.price) : null;
+      const tonEntry = prices.find(
+        (p) => p.address === 'native' || p.symbol?.toUpperCase() === 'TON',
+      );
+      const tonPriceUsd = tonEntry ? parseUsd(tonEntry.price) : null;
 
       // Use reserves from state.json (cached/indexed)
       // Note: state.json reserves are already formatted to human-readable decimals
@@ -92,9 +103,11 @@ export function useLivePoolData(): PoolData {
       // Look up CET price directly from prices endpoint
       const cetAddressLower = CET_CONTRACT_ADDRESS.toLowerCase();
       const cetEntry = prices.find(
-        (p) => p.address.toLowerCase() === cetAddressLower
+        (p) =>
+          (typeof p.address === 'string' && p.address.toLowerCase() === cetAddressLower) ||
+          p.symbol?.toUpperCase() === 'CET',
       );
-      let priceUsd: number | null = cetEntry ? parseFloat(cetEntry.price) : null;
+      let priceUsd: number | null = cetEntry ? parseUsd(cetEntry.price) : null;
 
       let tvlUsd: number | null = null;
       let volume24hUsd: number | null = null;
@@ -110,7 +123,7 @@ export function useLivePoolData(): PoolData {
 
         // Note: volume_24h is not in state.json yet, so we'll skip it or 
         // rely on a future indexer update to include it.
-        volume24hUsd = null; 
+        volume24hUsd = null;
       }
 
       setData({

--- a/app/src/sections/HeroSection.tsx
+++ b/app/src/sections/HeroSection.tsx
@@ -459,6 +459,9 @@ const HeroSection: React.FC<HeroSectionProps> = ({ cinematic = false }) => {
                   <div className="text-[10px] md:text-xs text-solaris-gold/80 tracking-[0.2em] uppercase mt-2 font-medium">
                     Preț curent
                   </div>
+                  <div className="text-[10px] text-slate-400 mt-1">
+                    {pool.error ? 'DeDust indisponibil' : 'Fără pereche activă'}
+                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Related issues

<!-- e.g. Closes #42 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor / quality (no behaviour change)
- [ ] Tests
- [ ] CI / tooling / dependencies
- [ ] Breaking change (describe migration below)

## Checklist

Run these from the repo root. This repo uses npm workspaces and a single root `package-lock.json`.

- [ ] `npm ci --legacy-peer-deps` succeeds
- [ ] `npm run app:verify` succeeds
- [ ] `PW_WORKERS=1 npm run app:test:e2e` succeeds (when UI/routes changed)
- [ ] `npm run contracts:test` succeeds (when contracts changed)
- [ ] `npm run contracts:typecheck` succeeds (when contracts changed)
- [ ] Tested manually in a browser when UI behaviour changed
- [ ] No unjustified `any`, no stray `console.log` / debug code in production paths
- [ ] New UI uses existing Tailwind / component patterns; GSAP plugins registered only where the project already does (e.g. `App.tsx`)
- [ ] Docs updated if user-facing behaviour or setup changed

## Screenshots / recordings

<!-- For visual changes, add before/after or a short clip. -->

## Breaking changes

<!-- If applicable: what breaks and how consumers should migrate. -->
