### PR TITLE
fix(dedust): link to coin page when pool is unavailable

### DIFF
--- a/app/src/__tests__/how-to-buy.test.ts
+++ b/app/src/__tests__/how-to-buy.test.ts
@@ -56,7 +56,7 @@ describe('HowToBuy + sitemap', () => {
     });
     const swap = HOW_TO_BUY_STEPS[2];
     expect(swap.cta.href).toBe(DEDUST_SWAP_URL);
-    expect(swap.cta.href).toContain(DEDUST_POOL_ADDRESS);
+    expect(swap.cta.href).toContain(CET_CONTRACT);
     expect(HOW_TO_BUY_STEPS[0].cta.href).toContain('tonkeeper.com');
     expect(HOW_TO_BUY_STEPS[0].id).toBe('wallet');
     expect(HOW_TO_BUY_STEPS[2].id).toBe('swap');

--- a/app/src/__tests__/site-sections.test.ts
+++ b/app/src/__tests__/site-sections.test.ts
@@ -349,7 +349,7 @@ describe("HowToBuy + sitemap", () => {
     });
     const swap = HOW_TO_BUY_STEPS[2];
     expect(swap.cta.href).toBe(DEDUST_SWAP_URL);
-    expect(swap.cta.href).toContain(DEDUST_POOL_ADDRESS);
+    expect(swap.cta.href).toContain(CET_CONTRACT);
     expect(HOW_TO_BUY_STEPS[0].cta.href).toContain("tonkeeper.com");
     expect(HOW_TO_BUY_STEPS[0].id).toBe("wallet");
     expect(HOW_TO_BUY_STEPS[2].id).toBe("swap");

--- a/app/src/lib/dedustUrls.ts
+++ b/app/src/lib/dedustUrls.ts
@@ -2,11 +2,15 @@
  * DeDust pool identifiers for CET on TON mainnet.
  * Single source of truth for swap / pool / deposit URLs in the app shell.
  */
+import { CET_CONTRACT_ADDRESS } from './cetContract';
+
 export const DEDUST_POOL_ADDRESS =
   'EQB5_hZPl4-EI1aWdLSd21c8T9PoKyZK2IJtrDFdPJIelfnB' as const;
 
-export const DEDUST_SWAP_URL = `https://dedust.io/swap/TON/${DEDUST_POOL_ADDRESS}` as const;
+export const DEDUST_COIN_PAGE_URL = `https://dedust.io/coins/${CET_CONTRACT_ADDRESS}` as const;
 
-export const DEDUST_POOL_PAGE_URL = `https://dedust.io/pools/${DEDUST_POOL_ADDRESS}` as const;
+export const DEDUST_SWAP_URL = DEDUST_COIN_PAGE_URL;
 
-export const DEDUST_POOL_DEPOSIT_URL = `${DEDUST_POOL_PAGE_URL}/deposit` as const;
+export const DEDUST_POOL_PAGE_URL = DEDUST_COIN_PAGE_URL;
+
+export const DEDUST_POOL_DEPOSIT_URL = DEDUST_COIN_PAGE_URL;


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Related issues

<!-- e.g. Closes #42 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor / quality (no behaviour change)
- [ ] Tests
- [ ] CI / tooling / dependencies
- [ ] Breaking change (describe migration below)

## Checklist

Run these from the repo root. This repo uses npm workspaces and a single root `package-lock.json`.

- [ ] `npm ci --legacy-peer-deps` succeeds
- [ ] `npm run app:verify` succeeds
- [ ] `PW_WORKERS=1 npm run app:test:e2e` succeeds (when UI/routes changed)
- [ ] `npm run contracts:test` succeeds (when contracts changed)
- [ ] `npm run contracts:typecheck` succeeds (when contracts changed)
- [ ] Tested manually in a browser when UI behaviour changed
- [ ] No unjustified `any`, no stray `console.log` / debug code in production paths
- [ ] New UI uses existing Tailwind / component patterns; GSAP plugins registered only where the project already does (e.g. `App.tsx`)
- [ ] Docs updated if user-facing behaviour or setup changed

## Screenshots / recordings

<!-- For visual changes, add before/after or a short clip. -->

## Breaking changes

<!-- If applicable: what breaks and how consumers should migrate. -->
