### PR TITLE
fix(indexer): detect CET/USDT stable or volatile pool

### DIFF
--- a/app/src/lib/chain-state.ts
+++ b/app/src/lib/chain-state.ts
@@ -20,6 +20,7 @@ export interface ChainTokenState {
 
 export interface ChainPoolState {
   address: string;
+  type?: 'volatile' | 'stable' | null;
   /** TON reserve as human-readable decimal string — or null if unknown */
   reserveTon: string | null;
   /** CET reserve as human-readable decimal string — or null if unknown */

--- a/scripts/ton-indexer.ts
+++ b/scripts/ton-indexer.ts
@@ -42,6 +42,7 @@ interface TokenState {
 
 interface PoolState {
   address: string;
+  type?: 'volatile' | 'stable' | null;
   reserveTon: string | null;
   reserveCet: string | null;
   assets?: string[] | null;
@@ -93,6 +94,7 @@ async function main(): Promise<void> {
   let reserveCet: bigint | null = null;
   let priceTonPerCet: string | null = null;
   let poolAddress: string | null = null;
+  let poolType: 'volatile' | 'stable' | null = null;
   let poolAssets: string[] | null = null;
   let poolReservesReadable: string[] | null = null;
 
@@ -103,25 +105,37 @@ async function main(): Promise<void> {
     const usdtAddress = Address.parse(USDT_JETTON_MASTER_ADDRESS);
     const usdtAsset = Asset.jetton(usdtAddress);
 
-    const pool = client.open(
-      await factory.getPool(PoolType.VOLATILE, [usdtAsset, cetAsset])
-    );
+    const poolCandidates: Array<{ type: 'stable' | 'volatile'; pool: unknown }> = [];
+    for (const t of [PoolType.STABLE, PoolType.VOLATILE] as const) {
+      try {
+        const pool = client.open(await factory.getPool(t, [usdtAsset, cetAsset]));
+        poolCandidates.push({ type: t === PoolType.STABLE ? 'stable' : 'volatile', pool });
+      } catch {
+        void 0;
+      }
+    }
+
+    const chosen = poolCandidates[0] as { type: 'stable' | 'volatile'; pool: any } | undefined;
+    if (!chosen) throw new Error('No DeDust CET/USDT pool found');
+    const pool = chosen.pool;
+    poolType = chosen.type;
 
     poolAddress = pool.address.toString();
 
     const [r0, r1] = await pool.getReserves();
     // reserves are aligned with requested asset order: [USDT, CET]
     const reserveUsdt = r0;
-    reserveCet = r1;
+    const reserveCetLocal = r1;
+    reserveCet = reserveCetLocal;
     reserveTon = null;
 
     poolAssets = [`jetton:${USDT_JETTON_MASTER_ADDRESS}`, `jetton:${CET_CONTRACT_ADDRESS}`];
     poolReservesReadable = [
       bigintToDecimalString(reserveUsdt, 6),
-      bigintToDecimalString(reserveCet, decimals),
+      bigintToDecimalString(reserveCetLocal, decimals),
     ];
 
-    console.log(`[ton-indexer] Pool reserves — USDT: ${reserveUsdt}, CET: ${reserveCet}`);
+    console.log(`[ton-indexer] Pool ${poolType} reserves — USDT: ${reserveUsdt}, CET: ${reserveCet}`);
   } catch (err) {
     console.warn('[ton-indexer] Failed to fetch DeDust pool data via SDK:', err);
 
@@ -141,6 +155,7 @@ async function main(): Promise<void> {
     },
     pool: {
       address: poolAddress ?? 'unknown',
+      type: poolType,
       reserveTon: reserveTon !== null
         ? bigintToDecimalString(reserveTon, 9)
         : null,


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Related issues

<!-- e.g. Closes #42 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor / quality (no behaviour change)
- [ ] Tests
- [ ] CI / tooling / dependencies
- [ ] Breaking change (describe migration below)

## Checklist

Run these from the repo root. This repo uses npm workspaces and a single root `package-lock.json`.

- [ ] `npm ci --legacy-peer-deps` succeeds
- [ ] `npm run app:verify` succeeds
- [ ] `PW_WORKERS=1 npm run app:test:e2e` succeeds (when UI/routes changed)
- [ ] `npm run contracts:test` succeeds (when contracts changed)
- [ ] `npm run contracts:typecheck` succeeds (when contracts changed)
- [ ] Tested manually in a browser when UI behaviour changed
- [ ] No unjustified `any`, no stray `console.log` / debug code in production paths
- [ ] New UI uses existing Tailwind / component patterns; GSAP plugins registered only where the project already does (e.g. `App.tsx`)
- [ ] Docs updated if user-facing behaviour or setup changed

## Screenshots / recordings

<!-- For visual changes, add before/after or a short clip. -->

## Breaking changes

<!-- If applicable: what breaks and how consumers should migrate. -->
